### PR TITLE
fix: use 8000 from local not docker container

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,7 +40,7 @@ http {
         client_max_body_size 10M;
 
         underscores_in_headers on;
-        set $appflowy_cloud_backend "http://appflowy_cloud:8000";
+        set $appflowy_cloud_backend "http://host.docker.internal:8000";
         set $gotrue_backend "http://gotrue:9999";
         set $admin_frontend_backend "http://admin_frontend:3000";
         set $appflowy_web_backend "http://appflowy_web:80";


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Modify Nginx configuration to route requests to the cloud backend running on the host machine (`host.docker.internal`) instead of a Docker container.